### PR TITLE
Date Validation For Sessions does not work properly #53

### DIFF
--- a/force-app/main/default/objects/Session__c/validationRules/Validate_Date.validationRule-meta.xml
+++ b/force-app/main/default/objects/Session__c/validationRules/Validate_Date.validationRule-meta.xml
@@ -2,11 +2,12 @@
 <ValidationRule xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Validate_Date</fullName>
     <active>true</active>
-    <errorConditionFormula>OR(
-   Start_Date_Time__c  &lt;=  Public_Event__r.Start_Date__c ,
- End_Date_Time__c  &gt;=  Public_Event__r.End_Date__c ,
- Start_Date_Time__c  &gt;=  Public_Event__r.End_Date__c ,
- End_Date_Time__c  &lt;=  Public_Event__r.Start_Date__c  
+    <errorConditionFormula>OR
+(
+ Start_Date_Time__c &lt; Public_Event__r.Start_Date__c,
+ Start_Date_Time__c &gt; Public_Event__r.End_Date__c,
+ End_Date_Time__c &lt; Public_Event__r.Start_Date__c,
+ End_Date_Time__c &gt; Public_Event__r.End_Date__c 
 )</errorConditionFormula>
     <errorMessage>Session&apos;s start and end date/time should be between Event&apos;s start and end date/time</errorMessage>
 </ValidationRule>


### PR DESCRIPTION
What has been Done:
- Validation rule “Validate_Date” under "Session" object condition formula is updated for given scenario

Test Cases:
Sessions can be created:
- Session created with the same start date time with its event
- Session created with the same end date time with its event

Sessions can’t be created (Error message “Session's start and end date/time should be between Event's start and end date/time" is showed on the screen):
- Session created with the smaller start date time with its event start date time
- Session created with the greater start date time with its event end date time
- Session created with the smaller end date time with its event start date time
- Session created with the greater end date time with its event end date time