### PR TITLE
Getting Address to the Event from Main Vanue

### DIFF
--- a/force-app/main/default/classes/PublicEvent_Test.cls
+++ b/force-app/main/default/classes/PublicEvent_Test.cls
@@ -1,0 +1,31 @@
+/*
+@Author:-Tuğrul GÜL
+@Description:- This code is created for Public Event Tests
+@Created:- 27/05/2022
+@Last Updated:- 27/05/2022
+*/
+@isTest
+public class PublicEvent_Test{
+
+    /* 
+    @param:- None
+    @description:- Inserts Public Events and Venues
+    @returns:- None
+    */
+    @isTest
+    static void testPublicEventwithVenues() {
+        Venue__c[] vList = TestDataFactory.createVenues(1);
+        Public_Event__c[] pList = TestDataFactory.createPublicEvents(5,vList);
+
+        List<Public_Event__c> peList = [SELECT Id, City__c, Country__c, Main_Venue__r.City__c, Main_Venue__r.Country__c FROM Public_Event__c];
+        for(Integer i = 0; i<5; i++ ){
+            if(math.mod(i, 2) == 0){
+                System.assertEquals(peList[i].Main_Venue__r.City__c, peList[i].City__c, 'City field was not updated from Main Venue' );
+                System.assertEquals(peList[i].Main_Venue__r.Country__c, peList[i].Country__c, 'Country field was not updated fromm Main Venue' );
+            }else{
+                System.assertEquals(peList[i].Main_Venue__r.City__c, peList[i].City__c, 'City field was not set for Public Event' );
+                System.assertEquals(peList[i].Main_Venue__r.Country__c, peList[i].Country__c, 'Country field was not set for Public Event' );
+            }
+        }
+    }
+}    

--- a/force-app/main/default/classes/PublicEvent_Test.cls-meta.xml
+++ b/force-app/main/default/classes/PublicEvent_Test.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>54.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/TestDataFactory.cls
+++ b/force-app/main/default/classes/TestDataFactory.cls
@@ -1,0 +1,108 @@
+/*
+@Author:-Tuğrul GÜL
+@Description:- This code is created for Test Setup Data
+@Created:- 27/05/2022
+@Last Updated:- 27/05/2022
+*/
+@isTest
+public class TestDataFactory {
+
+    /*
+    @param:- Integer numP , List<Venue__c> vList
+    @description:- Creates as many Public Events as numP value
+    @returns:- List<Public_Event__c> pList
+    */
+    public static List<Public_Event__c> createPublicEvents(Integer numP, List<Venue__c> vList) {
+        List<Public_Event__c> pList = new List<Public_Event__c>();
+        for(Integer i =0; i<numP;i++){
+            Public_Event__c pe = new Public_Event__c(   Name = 'Public Event Test ' + String.valueOf(i),
+                                                        Type__c = 'Dreamforce',
+                                                        Start_Date__c = Datetime.now(),
+                                                        End_Date__c = (Datetime.now()).addMonths(1),
+                                                        City__c = 'London',
+                                                        Country__c = 'England',
+                                                        Main_Venue__c = vList[0].Id
+                                                    );
+            if(math.mod(i, 2) == 0){
+                pe.City__c = null;
+                pe.Country__c = null;
+            }else{
+                pe.City__c = 'İzmir';
+                pe.Country__c = 'Türkiye';
+            }
+            pList.add(pe);
+        }
+        insert pList;
+        return pList;
+    }
+
+    /*
+    @param:- Integer numS, List<Public_Event__c> pList, List<Room__c> rList
+    @description:- Creates as many Public Events as numP value
+    @returns:- List<Session__c> pList
+    */
+    public static List<Session__c> createSessions(Integer numS, List<Public_Event__c> pList, List<Room__c> rList) {
+        List<Session__c> sList = new List<Session__c>();
+        for(Integer i = 0; i<numS; i++){
+            Session__c  s = new Session__c( Name = 'Session Test' + String.valueOf(i),
+                                            Public_Event__c = pList[0].Id,
+                                            Start_Date_Time__c = (Datetime.now()).addDays(i),
+                                            End_Date_Time__c = (Datetime.now()).addDays(i+2),
+                                            Room__c = rList[i].Id
+            );
+            if(math.mod(i, 2) == 0){
+                s.Is_Mandatory__c = true;
+            }else{
+                s.Is_Mandatory__c = false;
+            }
+            sList.add(s);
+        }
+        insert sList;
+        return sList;
+    }
+    
+    /*
+    @param:- Integer numV 
+    @description:- Creates as many Venues as numV value  
+    @returns:- List<Venues__c> vList
+    */
+    public static List<Venue__c> createVenues(Integer numV) {
+        List<Venue__c> vList = new List<Venue__c>();
+        for(Integer i = 0; i<numV; i++){
+            Venue__c ve = new Venue__c( Name = 'Venue Test '+ String.valueOf(i),
+                                        Street__c = 'Alsancak',
+                                        City__c = 'İzmir',
+                                        Country__c = 'Türkiye'
+                                    );
+            vList.add(ve);
+        }
+        insert vList;
+        return vList;
+    }
+
+    /*
+    @param:- Integer numR, List<Venue__c> vList
+    @description:- Creates as many Rooms as numP value
+    @returns:- List<Room__c> pList
+    */
+    public static List<Room__c> createRooms(Integer numR, List<Venue__c> vList){
+        List<Room__c> rList = new List<Room__c>();
+        for(Integer i = 0; i<numR; i++){
+            Room__c ro = new Room__c(   Name = 'Room Test' + String.valueOf(i),
+                                        Room_Capacity__c = 25 + i*25,
+                                        Venue__c = vList[0].Id
+        );
+        rList.add(ro);
+        }
+        
+        for(Integer i = 0; i<2; i++){
+            Room__c ro = new Room__c(   Name = 'Room Test' + String.valueOf(i),
+                                        Room_Capacity__c = 25 + i*25,
+                                        Venue__c = vList[1].Id
+        );
+        rList.add(ro);
+        }
+        insert rList;
+        return rList;
+    }
+}

--- a/force-app/main/default/classes/TestDataFactory.cls-meta.xml
+++ b/force-app/main/default/classes/TestDataFactory.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>54.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/flows/Before_Insert_Update_Public_Event.flow-meta.xml
+++ b/force-app/main/default/flows/Before_Insert_Update_Public_Event.flow-meta.xml
@@ -4,8 +4,8 @@
     <assignments>
         <name>Fill_Dates_Text</name>
         <label>Fill Dates(Text)</label>
-        <locationX>610</locationX>
-        <locationY>617</locationY>
+        <locationX>68</locationX>
+        <locationY>978</locationY>
         <assignmentItems>
             <assignToReference>$Record.Date_Start__c</assignToReference>
             <operator>Assign</operator>
@@ -21,22 +21,174 @@
             </value>
         </assignmentItems>
     </assignments>
+    <assignments>
+        <description>Set Public Event Address Information from Main Venue</description>
+        <name>Set_Public_Event_Address_Information</name>
+        <label>Set Public Event Address Information</label>
+        <locationX>622</locationX>
+        <locationY>758</locationY>
+        <assignmentItems>
+            <assignToReference>$Record.Street__c</assignToReference>
+            <operator>Assign</operator>
+            <value>
+                <elementReference>$Record.Main_Venue__r.Street__c</elementReference>
+            </value>
+        </assignmentItems>
+        <assignmentItems>
+            <assignToReference>$Record.City__c</assignToReference>
+            <operator>Assign</operator>
+            <value>
+                <elementReference>$Record.Main_Venue__r.City__c</elementReference>
+            </value>
+        </assignmentItems>
+        <assignmentItems>
+            <assignToReference>$Record.Country__c</assignToReference>
+            <operator>Assign</operator>
+            <value>
+                <elementReference>$Record.Main_Venue__r.Country__c</elementReference>
+            </value>
+        </assignmentItems>
+        <assignmentItems>
+            <assignToReference>$Record.Postal_Code__c</assignToReference>
+            <operator>Assign</operator>
+            <value>
+                <elementReference>$Record.Main_Venue__r.Postal_Code__c</elementReference>
+            </value>
+        </assignmentItems>
+        <connector>
+            <targetReference>Fill_Dates_Text</targetReference>
+        </connector>
+    </assignments>
     <decisions>
-        <name>Dates_for_Set</name>
-        <label>Dates for Set</label>
-        <locationX>600</locationX>
-        <locationY>383</locationY>
+        <name>Address_Information_is_Set_or_Not</name>
+        <label>Address Information is Set or Not</label>
+        <locationX>55</locationX>
+        <locationY>460</locationY>
+        <defaultConnector>
+            <targetReference>Fill_Dates_Text</targetReference>
+        </defaultConnector>
         <defaultConnectorLabel>Default Outcome</defaultConnectorLabel>
         <rules>
-            <name>Dates_are_Insert_or_Changed</name>
-            <conditionLogic>or</conditionLogic>
+            <name>Is_not_Set</name>
+            <conditionLogic>and</conditionLogic>
             <conditions>
-                <leftValueReference>ISNEW</leftValueReference>
-                <operator>EqualTo</operator>
+                <leftValueReference>$Record.Street__c</leftValueReference>
+                <operator>IsNull</operator>
                 <rightValue>
                     <booleanValue>true</booleanValue>
                 </rightValue>
             </conditions>
+            <conditions>
+                <leftValueReference>$Record.City__c</leftValueReference>
+                <operator>IsNull</operator>
+                <rightValue>
+                    <booleanValue>true</booleanValue>
+                </rightValue>
+            </conditions>
+            <conditions>
+                <leftValueReference>$Record.Country__c</leftValueReference>
+                <operator>IsNull</operator>
+                <rightValue>
+                    <booleanValue>true</booleanValue>
+                </rightValue>
+            </conditions>
+            <conditions>
+                <leftValueReference>$Record.Postal_Code__c</leftValueReference>
+                <operator>IsNull</operator>
+                <rightValue>
+                    <booleanValue>true</booleanValue>
+                </rightValue>
+            </conditions>
+            <connector>
+                <targetReference>Set_Public_Event_Address_Information</targetReference>
+            </connector>
+            <label>Is not Set</label>
+        </rules>
+    </decisions>
+    <decisions>
+        <description>Controls address information is changed and null</description>
+        <name>Address_Information_Status</name>
+        <label>Address Information Status</label>
+        <locationX>1186</locationX>
+        <locationY>461</locationY>
+        <defaultConnector>
+            <targetReference>Dates_for_Set</targetReference>
+        </defaultConnector>
+        <defaultConnectorLabel>Default Outcome</defaultConnectorLabel>
+        <rules>
+            <name>Is_Changed_and_Null</name>
+            <conditionLogic>(1 OR 2 OR 3 OR 4) AND 5 AND 6 AND 7 AND 8</conditionLogic>
+            <conditions>
+                <leftValueReference>$Record.Street__c</leftValueReference>
+                <operator>IsChanged</operator>
+                <rightValue>
+                    <booleanValue>true</booleanValue>
+                </rightValue>
+            </conditions>
+            <conditions>
+                <leftValueReference>$Record.City__c</leftValueReference>
+                <operator>IsChanged</operator>
+                <rightValue>
+                    <booleanValue>true</booleanValue>
+                </rightValue>
+            </conditions>
+            <conditions>
+                <leftValueReference>$Record.Country__c</leftValueReference>
+                <operator>IsChanged</operator>
+                <rightValue>
+                    <booleanValue>true</booleanValue>
+                </rightValue>
+            </conditions>
+            <conditions>
+                <leftValueReference>$Record.Postal_Code__c</leftValueReference>
+                <operator>IsChanged</operator>
+                <rightValue>
+                    <booleanValue>true</booleanValue>
+                </rightValue>
+            </conditions>
+            <conditions>
+                <leftValueReference>$Record.Street__c</leftValueReference>
+                <operator>IsNull</operator>
+                <rightValue>
+                    <booleanValue>true</booleanValue>
+                </rightValue>
+            </conditions>
+            <conditions>
+                <leftValueReference>$Record.City__c</leftValueReference>
+                <operator>IsNull</operator>
+                <rightValue>
+                    <booleanValue>true</booleanValue>
+                </rightValue>
+            </conditions>
+            <conditions>
+                <leftValueReference>$Record.Country__c</leftValueReference>
+                <operator>IsNull</operator>
+                <rightValue>
+                    <booleanValue>true</booleanValue>
+                </rightValue>
+            </conditions>
+            <conditions>
+                <leftValueReference>$Record.Postal_Code__c</leftValueReference>
+                <operator>IsNull</operator>
+                <rightValue>
+                    <booleanValue>true</booleanValue>
+                </rightValue>
+            </conditions>
+            <connector>
+                <targetReference>Set_Public_Event_Address_Information</targetReference>
+            </connector>
+            <label>Is Changed and Null</label>
+        </rules>
+    </decisions>
+    <decisions>
+        <name>Dates_for_Set</name>
+        <label>Dates for Set</label>
+        <locationX>1187</locationX>
+        <locationY>982</locationY>
+        <defaultConnectorLabel>Default Outcome</defaultConnectorLabel>
+        <rules>
+            <name>Dates_are_Insert_or_Changed</name>
+            <conditionLogic>or</conditionLogic>
             <conditions>
                 <leftValueReference>$Record.Start_Date__c</leftValueReference>
                 <operator>IsChanged</operator>
@@ -57,7 +209,45 @@
             <label>Dates are Insert or Changed</label>
         </rules>
     </decisions>
-    <description>Fill &quot;DateStart&quot; &amp; &quot;DateEnd&quot; fields</description>
+    <decisions>
+        <name>Insert_or_Update</name>
+        <label>Insert or Update</label>
+        <locationX>599</locationX>
+        <locationY>451</locationY>
+        <defaultConnectorLabel>Default Outcome</defaultConnectorLabel>
+        <rules>
+            <name>Insert</name>
+            <conditionLogic>and</conditionLogic>
+            <conditions>
+                <leftValueReference>ISNEW</leftValueReference>
+                <operator>EqualTo</operator>
+                <rightValue>
+                    <booleanValue>true</booleanValue>
+                </rightValue>
+            </conditions>
+            <connector>
+                <targetReference>Address_Information_is_Set_or_Not</targetReference>
+            </connector>
+            <label>Insert</label>
+        </rules>
+        <rules>
+            <name>Update</name>
+            <conditionLogic>and</conditionLogic>
+            <conditions>
+                <leftValueReference>ISNEW</leftValueReference>
+                <operator>EqualTo</operator>
+                <rightValue>
+                    <booleanValue>false</booleanValue>
+                </rightValue>
+            </conditions>
+            <connector>
+                <targetReference>Address_Information_Status</targetReference>
+            </connector>
+            <label>Update</label>
+        </rules>
+    </decisions>
+    <description>Set &quot;DateStart&quot; &amp; &quot;DateEnd&quot; fields &amp;
+Set Address Information from Main Venue, if It&apos;s not set for Public Event</description>
     <formulas>
         <description>End date of Public Event</description>
         <name>EndDate</name>
@@ -100,7 +290,7 @@
         <locationX>489</locationX>
         <locationY>28</locationY>
         <connector>
-            <targetReference>Dates_for_Set</targetReference>
+            <targetReference>Insert_or_Update</targetReference>
         </connector>
         <object>Public_Event__c</object>
         <recordTriggerType>CreateAndUpdate</recordTriggerType>

--- a/force-app/main/default/flows/Before_Insert_Update_Public_Event.flow-meta.xml
+++ b/force-app/main/default/flows/Before_Insert_Update_Public_Event.flow-meta.xml
@@ -117,7 +117,7 @@
         <defaultConnectorLabel>Default Outcome</defaultConnectorLabel>
         <rules>
             <name>Is_Changed_and_Null</name>
-            <conditionLogic>(1 OR 2 OR 3 OR 4) AND 5 AND 6 AND 7 AND 8</conditionLogic>
+            <conditionLogic>((1 AND 5) OR 5) AND ((2 AND 6) OR 6) AND ((3 AND 7) OR 7) AND ((4 AND 8) OR 8)</conditionLogic>
             <conditions>
                 <leftValueReference>$Record.Street__c</leftValueReference>
                 <operator>IsChanged</operator>

--- a/force-app/main/default/layouts/Public_Event__c-Public Event Layout.layout-meta.xml
+++ b/force-app/main/default/layouts/Public_Event__c-Public Event Layout.layout-meta.xml
@@ -55,11 +55,11 @@
                 <field>Street__c</field>
             </layoutItems>
             <layoutItems>
-                <behavior>Required</behavior>
+                <behavior>Edit</behavior>
                 <field>City__c</field>
             </layoutItems>
             <layoutItems>
-                <behavior>Required</behavior>
+                <behavior>Edit</behavior>
                 <field>Country__c</field>
             </layoutItems>
             <layoutItems>

--- a/force-app/main/default/objects/Public_Event__c/fields/City__c.field-meta.xml
+++ b/force-app/main/default/objects/Public_Event__c/fields/City__c.field-meta.xml
@@ -4,7 +4,7 @@
     <externalId>false</externalId>
     <label>City</label>
     <length>40</length>
-    <required>true</required>
+    <required>false</required>
     <trackTrending>false</trackTrending>
     <type>Text</type>
     <unique>false</unique>

--- a/force-app/main/default/objects/Public_Event__c/fields/Country__c.field-meta.xml
+++ b/force-app/main/default/objects/Public_Event__c/fields/Country__c.field-meta.xml
@@ -4,7 +4,7 @@
     <externalId>false</externalId>
     <label>Country</label>
     <length>40</length>
-    <required>true</required>
+    <required>false</required>
     <trackTrending>false</trackTrending>
     <type>Text</type>
     <unique>false</unique>

--- a/force-app/main/default/profiles/Admin.profile-meta.xml
+++ b/force-app/main/default/profiles/Admin.profile-meta.xml
@@ -186,6 +186,16 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>true</editable>
+        <field>Public_Event__c.City__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>Public_Event__c.Country__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
         <field>Public_Event__c.Date_End__c</field>
         <readable>true</readable>
     </fieldPermissions>


### PR DESCRIPTION
- “TestDataFactory” and “PublicEvent_Test” classes are created

- “City” and “Country” fields under the “Public Events” object are set as “not required” fields

- “Before Insert Update Public Event” flow is updated. It sets Address information of “Public Events” from Main Venue, İf  it’s not set at “Public Event”


Test Case Document: 
[Test Case#79.pdf](https://github.com/sgoEma/EventManagement/files/8796319/Test.Case.79.pdf)


Org Credentials: 
test-qitf4genvua0@example.com 
Alt(cngv8byys 

Best, TG